### PR TITLE
Fix: Logout clears storage and redirects to Login

### DIFF
--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -17,6 +17,26 @@ class _LoginScreenState extends State<LoginScreen> {
   final TextEditingController passwordController = TextEditingController();
   bool _isPasswordVisible = false;
 
+  @override
+  void initState() {
+    super.initState();
+    _checkLoginStatus(); // check if token exists
+  }
+
+  // Check token in local storage
+  void _checkLoginStatus() async {
+    final prefs = await SharedPreferences.getInstance();
+    final token = prefs.getString("token");
+
+    if (token != null && token.isNotEmpty) {
+      if (!mounted) return;
+      Navigator.pushReplacement(
+        context,
+        MaterialPageRoute(builder: (context) => const DashboardScreen()),
+      );
+    }
+  }
+
   // LOGIN FUNCTION :
   void handleLogin() async {
     final email = emailController.text.trim();
@@ -25,17 +45,16 @@ class _LoginScreenState extends State<LoginScreen> {
     if (email.isEmpty || password.isEmpty) {
       showDialog(
         context: context,
-        builder:
-            (context) => AlertDialog(
-              title: const Text("Error"),
-              content: const Text("Please enter both email and password."),
-              actions: [
-                TextButton(
-                  onPressed: () => Navigator.pop(context),
-                  child: const Text("OK"),
-                ),
-              ],
+        builder: (context) => AlertDialog(
+          title: const Text("Error"),
+          content: const Text("Please enter both email and password."),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text("OK"),
             ),
+          ],
+        ),
       );
       return;
     }
@@ -70,40 +89,37 @@ class _LoginScreenState extends State<LoginScreen> {
           context,
           MaterialPageRoute(builder: (context) => const DashboardScreen()),
         );
-        // TODO: Navigate to dashboard screen if needed and store token/user info
       } else {
         showDialog(
           context: context,
-          builder:
-              (context) => AlertDialog(
-                title: const Text("Login Failed"),
-                content: Text(
-                  responseData["message"] ?? "Invalid credentials.",
-                ),
-                actions: [
-                  TextButton(
-                    onPressed: () => Navigator.pop(context),
-                    child: const Text("OK"),
-                  ),
-                ],
+          builder: (context) => AlertDialog(
+            title: const Text("Login Failed"),
+            content: Text(
+              responseData["message"] ?? "Invalid credentials.",
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(context),
+                child: const Text("OK"),
               ),
+            ],
+          ),
         );
       }
     } catch (e) {
-      if (!mounted) return; // widget abhi mounted hai ya nahi check karo
+      if (!mounted) return;
       showDialog(
         context: context,
-        builder:
-            (context) => AlertDialog(
-              title: const Text("Connection Error"),
-              content: Text("Failed to connect to server.\n\nError: $e"),
-              actions: [
-                TextButton(
-                  onPressed: () => Navigator.pop(context),
-                  child: const Text("OK"),
-                ),
-              ],
+        builder: (context) => AlertDialog(
+          title: const Text("Connection Error"),
+          content: Text("Failed to connect to server.\n\nError: $e"),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text("OK"),
             ),
+          ],
+        ),
       );
     }
   }

--- a/lib/widgets/drawer.dart
+++ b/lib/widgets/drawer.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:mandimate_mobile_app/screens/dashboard_screen.dart';
 import 'package:mandimate_mobile_app/screens/seasonOverview_screen.dart';
+import 'package:mandimate_mobile_app/screens/login_screen.dart'; 
+import 'package:shared_preferences/shared_preferences.dart';   
 
 class CustomDrawer extends StatelessWidget {
   const CustomDrawer({super.key});
@@ -122,8 +124,15 @@ class CustomDrawer extends StatelessWidget {
                 ],
               ),
               child: ElevatedButton.icon(
-                onPressed: () {
-                  // TODO: Logout Logic
+                onPressed: () async {
+                  final prefs = await SharedPreferences.getInstance();
+                  await prefs.clear(); //  local storage clear
+
+                  Navigator.pushAndRemoveUntil(
+                    context,
+                    MaterialPageRoute(builder: (context) => const LoginScreen()),
+                    (Route<dynamic> route) => false, //  all screens clear
+                  );
                 },
                 icon: const Icon(Icons.logout, color: Colors.white),
                 label: const Text(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
+      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.13.0"
   barcode:
     dependency: transitive
     description:
@@ -93,10 +93,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   ffi:
     dependency: transitive
     description:
@@ -180,10 +180,10 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "10.0.9"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -465,10 +465,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
+      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.1"
+    version: "15.0.0"
   web:
     dependency: transitive
     description:


### PR DESCRIPTION
Summary :
1 : Added logout logic with SharedPreferences.clear
2 : Redirects to LoginScreen after logout.
3 :  On app start: 
  - If token exists → go to Dashboard. 
  - If no token → stay on Login.

 Fix  :
Ensures user cannot access Dashboard after logout unless logged in again.
